### PR TITLE
Dockerfile + build process + daemonset + README updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: go
 # for the detail
 # sudo: requried
 dist: trusty
+env:
+  global:
+    - REGISTRY_USER=nfvperobot
+    - secure: "ca+qSuPGFyg75kspazh0W21sk/0Eag8jD5Hwq8br0mr3KMt/OvujEbvvEekHIS1i8gn27NQPHKQxWMF2ntZr6obD28GfOc88w4SaWJDp4lFR4x2VvpKdPIqHKVxt3DRwJ4YKLH3E70QL4bJAh4ScxI0AeKB3EDCh4wOwEWF7AfjgKNfNFxoJa5arfdd1nfGfGjHEArHO39YY5uXZmdWGEQ/QyCDJy39RQcrqwvfErM6GXoO43cmRJkzEh45A5M/bdZ+6wpR/LKevp2ftWprOref4Y9GevJoEtDzZb47CXMZSmjB7JJUj9vWUiGrGm0TSZwJfOsw07Fs1ZzE5IHgSwdPldVn+XUCQICJY7pS3mAnyJ+lwCnrzTvKYd46V08JJ/VJzfZFlgbsygiMdPMypfEZ/0Ll51MXKFH3mPP2KYxjkgUZA8CAPvSWpMeLLAO+neSVas+CC5+C3pfaBEYGbLGZXim7Jtdxw2nVeOKaKQLZn/c3W+zrTbWV/obYOfUH5x0XS9IA/J6aUm4M3tq3n0SVGIk3EKi7fF4kESf0xW+6IyKEFs8k1tynQhWZ7i4gTwQ9ug+XyIm6HWGfUz3YkZVkLQhHDfwJ9DSYvXO3seWigY1GkY+dDys5Nb+loiR1Y0mKrDFdTw91GIpde3ayys/b+Klj0RYY17CWuQEh+9NA="
 
 before_install:
   - sudo apt-get update -qq
@@ -20,5 +24,17 @@ before_script:
 script:
   - go build dummy.go
 
+# These are kind of better than "after_success" as they can be more conditional
+# e.g. when merging into master.
+# before_deploy:
+# deploy:
+#   provider: script
+#   script: docker push nfvpe/dummy-dp
+#   on:
+#     branch: master
+
+# Using this for now so it triggers every time other tests succeed.
 after_success:
-  # stub.
+  - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
+  - docker build -t nfvpe/dummy-dp .
+  - docker push nfvpe/dummy-dp

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: trusty
 env:
   global:
     - REGISTRY_USER=nfvperobot
-    - secure: "ca+qSuPGFyg75kspazh0W21sk/0Eag8jD5Hwq8br0mr3KMt/OvujEbvvEekHIS1i8gn27NQPHKQxWMF2ntZr6obD28GfOc88w4SaWJDp4lFR4x2VvpKdPIqHKVxt3DRwJ4YKLH3E70QL4bJAh4ScxI0AeKB3EDCh4wOwEWF7AfjgKNfNFxoJa5arfdd1nfGfGjHEArHO39YY5uXZmdWGEQ/QyCDJy39RQcrqwvfErM6GXoO43cmRJkzEh45A5M/bdZ+6wpR/LKevp2ftWprOref4Y9GevJoEtDzZb47CXMZSmjB7JJUj9vWUiGrGm0TSZwJfOsw07Fs1ZzE5IHgSwdPldVn+XUCQICJY7pS3mAnyJ+lwCnrzTvKYd46V08JJ/VJzfZFlgbsygiMdPMypfEZ/0Ll51MXKFH3mPP2KYxjkgUZA8CAPvSWpMeLLAO+neSVas+CC5+C3pfaBEYGbLGZXim7Jtdxw2nVeOKaKQLZn/c3W+zrTbWV/obYOfUH5x0XS9IA/J6aUm4M3tq3n0SVGIk3EKi7fF4kESf0xW+6IyKEFs8k1tynQhWZ7i4gTwQ9ug+XyIm6HWGfUz3YkZVkLQhHDfwJ9DSYvXO3seWigY1GkY+dDys5Nb+loiR1Y0mKrDFdTw91GIpde3ayys/b+Klj0RYY17CWuQEh+9NA="
+    - secure: "W0weIu0SPyhxwdmLWrgWp8PoKpmnsUSR++P5f5rit0V+qc139n0pXwAyQ7BNAeOK9ZvcYXBAFltKhBt1bbO29Cu65eSdVPgyL7aozeBpKX7ANYlnF24KJYKWg4iGuIuJYNnVTwpf/4cT4DkfKgs8jWjK6rKcHTFXxvgdy7eKGNfq4W7IJv0nEYGyMMo1+3UcWJu8kr4+tSEJk/j4M0+SDoueal8Lt79WyhTihrCyYoq5rvim5d1wZtLN4ouaEfu1uhkJbYKwwg3UKFjdnzqABW5nrHBtOU1CtdVC1S21E6r1GtgeFpiSGnNl8q0Ki9zk4c7yge+u1eUSBi0h3KGP7+BeI8k3UwPfOM2UZ5VVCqSaIWLv6kOcrSZLWV1FClboj+RkwgKf7yD443b44fpH0flnyqzZMXVfMQDqbX1j/wOUaVMzPXKrVni4jW+AF5hOkePg8DMv2zN7Kk9xa0s3Z8OCcoG6LEJ19fY5CeRpfxvnS7iF2RU0gUphwXChrB/bNYMU9TW+6j+QPbKtaSlmvwXWM1uUOvTX9pIKSjWwV5ihlhE83JGYeMNd1Zw3Uk/YmmBRWIUl4p0nScUbzza3qxEBUVep4UYb6XN47WZFLP+sT5vLGIw5QmSNyc3M0JO+b/U2uNPr8+6Mh6BkkVt+z1UfVa7hXCw8yz7YH655U/Q="
 
 before_install:
   - sudo apt-get update -qq
@@ -22,7 +22,7 @@ before_script:
   # - gocyclo -over 15 .
 
 script:
-  - go build dummy.go
+  - go build -o k8s-dummy-device-plugin
 
 # These are kind of better than "after_success" as they can be more conditional
 # e.g. when merging into master.
@@ -36,5 +36,5 @@ script:
 # Using this for now so it triggers every time other tests succeed.
 after_success:
   - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
-  - docker build -t nfvpe/dummy-dp .
-  - docker push nfvpe/dummy-dp
+  - docker build -t nfvpe/dummy-device-plugin .
+  - docker push nfvpe/dummy-device-plugin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: go
+# see https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments
+# for the detail
+# sudo: requried
+dist: trusty
+
+before_install:
+  - sudo apt-get update -qq
+
+install:
+  - go get github.com/golang/lint/golint
+
+before_script:
+  - golint .
+  - go fmt .
+  - go vet .
+  # was failing with: `gocyclo: vendor/golang.org/x/net/context/go19.go:15:14: expected type, found '=' (and 1 more errors)`
+  # - gocyclo -over 15 .
+
+script:
+  - go build dummy.go
+
+after_success:
+  # stub.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM centos:centos7

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ WORKDIR /usr/src/
 RUN git clone https://github.com/dougbtv/k8s-dummy-device-plugin.git
 WORKDIR /usr/src/k8s-dummy-device-plugin
 # RUN go build dummy.go
-RUN CGO_ENABLED=0 go build -a dummy.go
+RUN CGO_ENABLED=0 go build -a dummy.go -o k8s-dummy-device-plugin
 
 # Copy phase
 FROM alpine:latest
 # If you need to debug, add bash.
 # RUN apk add --no-cache bash
-COPY --from=builder /usr/src/k8s-dummy-device-plugin/dummy /dummy
+COPY --from=builder /usr/src/k8s-dummy-device-plugin/k8s-dummy-device-plugin /k8s-dummy-device-plugin
 COPY --from=builder /usr/src/k8s-dummy-device-plugin/dummyResources.json /dummyResources.json
-ENTRYPOINT ["/dummy"]
+ENTRYPOINT ["/k8s-dummy-device-plugin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,19 @@
-FROM centos:centos7
+# Builder phase.
+FROM golang:1.10 AS builder
+MAINTAINER dosmith@redhat.com
+ENV build_date 2018-04-12
+ENV GOPATH /usr/
+RUN mkdir -p /usr/src/
+WORKDIR /usr/src/
+RUN git clone https://github.com/dougbtv/k8s-dummy-device-plugin.git
+WORKDIR /usr/src/k8s-dummy-device-plugin
+# RUN go build dummy.go
+RUN CGO_ENABLED=0 go build -a dummy.go
+
+# Copy phase
+FROM alpine:latest
+# If you need to debug, add bash.
+# RUN apk add --no-cache bash
+COPY --from=builder /usr/src/k8s-dummy-device-plugin/dummy /dummy
+COPY --from=builder /usr/src/k8s-dummy-device-plugin/dummyResources.json /dummyResources.json
+ENTRYPOINT ["/dummy"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In essence, it works as a kind of echo device. One specifies the (albeit pretend
 
 ## Building
 
-This plugin is built by simply building the `dummy.go` file, such as:
+This plugin is built by simply building the `dummy.go` file. Make sure your `$GOPATH` is set correctly and build with:
 
 ```
 go build dummy.go
@@ -16,14 +16,29 @@ go build dummy.go
 
 Dependencies are managed and versioned internally with [dep](https://github.com/golang/dep).
 
-## Deployment via daemonSet
+## Example Usage (when deployed as DaemonSet)
 
+In the `./examples/` directory there is an example DaemonSet that will deploy the device plugin on each node in your cluster.
 
+```
+kubectl create -f ./examples/daemonset.yml
+```
 
-## Usage
+Then create the sample pod, available as `./sample_pod.yaml` in this repository.
 
-Currently, no arguments are honored at runtime.
+```
+$ kubectl create -f ./sample_pod.yaml
+```
+
+You may then see that the "devices" were created as environment variables.
+
+```
+$ kubectl exec -it dummy-pod -- /bin/sh -c "printenv" | grep DUMMY_DEVICES
+DUMMY_DEVICES=dev_3,dev_4
+```
 
 ## Configuration
 
 Configuration of the "pretend" devices are in the `./dummyResources.json` file.
+
+More configuration to come.

--- a/README.md
+++ b/README.md
@@ -8,4 +8,22 @@ In essence, it works as a kind of echo device. One specifies the (albeit pretend
 
 ## Building
 
-This plugin is built by 
+This plugin is built by simply building the `dummy.go` file, such as:
+
+```
+go build dummy.go
+```
+
+Dependencies are managed and versioned internally with [dep](https://github.com/golang/dep).
+
+## Deployment via daemonSet
+
+
+
+## Usage
+
+Currently, no arguments are honored at runtime.
+
+## Configuration
+
+Configuration of the "pretend" devices are in the `./dummyResources.json` file.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # k8s-dummy-device-plugin
-K8s Dummy Device Plugin for testing purpose only
+
+K8s Dummy Device Plugin *(for testing purpose only)*
+
+This is a plugin that's used for testing and exploring [Kubernetes Device Plugins](https://kubernetes.io/docs/concepts/cluster-administration/device-plugins/).
+
+In essence, it works as a kind of echo device. One specifies the (albeit pretend) devices in a JSON file, and the plugin operates on those, and allocates the devices to containers that request them -- it does this by setting those devices into environment variables in those containers.
+
+## Building
+
+This plugin is built by 

--- a/examples/daemonset.yml
+++ b/examples/daemonset.yml
@@ -1,0 +1,39 @@
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: dummy-device-daemonset
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
+      # reserves resources for critical add-on pods so that they can be rescheduled after
+      # a failure.  This annotation works in tandem with the toleration below.
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: dummy-device-plugin-ds
+    spec:
+      tolerations:
+      # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
+      # This, along with the annotation above marks this pod as a critical add-on.
+      - key: CriticalAddonsOnly
+        operator: Exists
+      hostNetwork: true
+      containers:
+      - image: nfvpe/dummy-device-plugin:latest
+        name: dummy-device-plugin-ctr
+        # args: ["-log-level", "debug"]
+        # --------- Doug removed this section.
+        # securityContext:
+        #   allowPrivilegeEscalation: false
+        #   capabilities:
+        #     drop: ["ALL"]
+        volumeMounts:
+          - name: device-plugin
+            mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins


### PR DESCRIPTION
Adds:

* Updates to readme, showing some sample usage, sample build
* Daemonset to build the pod
* Dockerfile to build an image
* Travis for lint & also to push docker

Some of these things aren't properly namespaced -- due to the CI side of things, and refer to kind of "doug & nfvpe" so, we need to move this to the NFVPE repo to fix those up. I created #7 to follow up on this. However, should work with the Daemonset as advertised in the readme, had a test through that.

Fixes #1
Fixes #6 