### PR TITLE
[bugfix] Wrong parameter order for go build in Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
 
 script:
   - go build -o k8s-dummy-device-plugin
+  - docker build -t nfvpe/dummy-device-plugin .
 
 # These are kind of better than "after_success" as they can be more conditional
 # e.g. when merging into master.
@@ -36,5 +37,4 @@ script:
 # Using this for now so it triggers every time other tests succeed.
 after_success:
   - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
-  - docker build -t nfvpe/dummy-device-plugin .
-  - docker push nfvpe/dummy-device-plugin
+    - docker push nfvpe/dummy-device-plugin

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/src/
 RUN git clone https://github.com/dougbtv/k8s-dummy-device-plugin.git
 WORKDIR /usr/src/k8s-dummy-device-plugin
 # RUN go build dummy.go
-RUN CGO_ENABLED=0 go build -a dummy.go -o k8s-dummy-device-plugin
+RUN CGO_ENABLED=0 go build -a -o k8s-dummy-device-plugin dummy.go 
 
 # Copy phase
 FROM alpine:latest


### PR DESCRIPTION
Ahhh, Travis didn't error on this because it's "after success" -- turns out it was causing the docker image to not be pushed properly, because the build didn't finish. 

In alignment with that, added the Docker build to the main script to ensure that the image build is verified as well, which would've caught this in the first place.

Going to merge it right up as it impaired the functionality without it / it's a hot fix.